### PR TITLE
Implement recommendation service and model relations

### DIFF
--- a/minha-livraria/app/Http/Controllers/LivroController.php
+++ b/minha-livraria/app/Http/Controllers/LivroController.php
@@ -5,10 +5,18 @@ namespace App\Http\Controllers;
 
 use App\Models\Livro;
 use App\Models\Categoria;
+use App\Services\RecomendacaoService;
 use Illuminate\Http\Request;
 
 class LivroController extends Controller
 {
+    private RecomendacaoService $recomendacaoService;
+
+    public function __construct(RecomendacaoService $recomendacaoService)
+    {
+        $this->recomendacaoService = $recomendacaoService;
+    }
+
     public function index(Request $request)
     {
         $query = Livro::with('categoria')->ativo();
@@ -64,14 +72,7 @@ class LivroController extends Controller
     {
         $livro = Livro::with('categoria')->where('slug', $slug)->ativo()->firstOrFail();
         
-        // Livros relacionados da mesma categoria
-        $livrosRelacionados = Livro::with('categoria')
-            ->where('categoria_id', $livro->categoria_id)
-            ->where('id', '!=', $livro->id)
-            ->ativo()
-            ->inRandomOrder()
-            ->limit(4)
-            ->get();
+        $livrosRelacionados = $this->recomendacaoService->recomendar($livro, auth()->user());
 
         return view('livros.show', compact('livro', 'livrosRelacionados'));
     }

--- a/minha-livraria/app/Http/Controllers/RecomendacaoController.php
+++ b/minha-livraria/app/Http/Controllers/RecomendacaoController.php
@@ -2,9 +2,23 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Models\Livro;
+use App\Services\RecomendacaoService;
 
 class RecomendacaoController extends Controller
 {
-    //
+    private RecomendacaoService $service;
+
+    public function __construct(RecomendacaoService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function show(Livro $livro)
+    {
+        $user = auth()->user();
+        $recomendados = $this->service->recomendar($livro, $user);
+
+        return response()->json($recomendados);
+    }
 }

--- a/minha-livraria/app/Models/Avaliacao.php
+++ b/minha-livraria/app/Models/Avaliacao.php
@@ -6,5 +6,21 @@ use Illuminate\Database\Eloquent\Model;
 
 class Avaliacao extends Model
 {
-    //
+    protected $fillable = [
+        'user_id',
+        'livro_id',
+        'rating',
+        'comentario',
+        'status',
+    ];
+
+    public function livro()
+    {
+        return $this->belongsTo(Livro::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/minha-livraria/app/Models/Cupom.php
+++ b/minha-livraria/app/Models/Cupom.php
@@ -6,5 +6,22 @@ use Illuminate\Database\Eloquent\Model;
 
 class Cupom extends Model
 {
-    //
+    protected $fillable = [
+        'codigo',
+        'descricao',
+        'tipo',
+        'valor',
+        'ativo',
+        'validade',
+    ];
+
+    protected $casts = [
+        'ativo' => 'boolean',
+        'validade' => 'datetime',
+    ];
+
+    public function pedidos()
+    {
+        return $this->hasMany(Pedido::class);
+    }
 }

--- a/minha-livraria/app/Models/Livro.php
+++ b/minha-livraria/app/Models/Livro.php
@@ -6,6 +6,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use App\Models\PedidoItem;
+use App\Models\Avaliacao;
+use App\Models\Wishlist;
 
 class Livro extends Model
 {
@@ -46,6 +49,21 @@ class Livro extends Model
     public function carrinhoItens()
     {
         return $this->hasMany(CarrinhoItem::class);
+    }
+
+    public function pedidoItens()
+    {
+        return $this->hasMany(PedidoItem::class);
+    }
+
+    public function avaliacoes()
+    {
+        return $this->hasMany(Avaliacao::class);
+    }
+
+    public function wishlists()
+    {
+        return $this->hasMany(Wishlist::class);
     }
 
     public function getPrecoFinalAttribute()

--- a/minha-livraria/app/Models/NewsletterSubscriber.php
+++ b/minha-livraria/app/Models/NewsletterSubscriber.php
@@ -6,5 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class NewsletterSubscriber extends Model
 {
-    //
+    protected $fillable = [
+        'email',
+        'token',
+        'confirmed_at',
+    ];
+
+    protected $casts = [
+        'confirmed_at' => 'datetime',
+    ];
 }

--- a/minha-livraria/app/Models/User.php
+++ b/minha-livraria/app/Models/User.php
@@ -6,6 +6,10 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Carrinho;
+use App\Models\Pedido;
+use App\Models\Wishlist;
+use App\Models\Avaliacao;
 
 class User extends Authenticatable
 {
@@ -44,5 +48,25 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function pedidos()
+    {
+        return $this->hasMany(Pedido::class);
+    }
+
+    public function carrinhos()
+    {
+        return $this->hasMany(Carrinho::class);
+    }
+
+    public function wishlist()
+    {
+        return $this->hasMany(Wishlist::class);
+    }
+
+    public function avaliacoes()
+    {
+        return $this->hasMany(Avaliacao::class);
     }
 }

--- a/minha-livraria/app/Models/Wishlist.php
+++ b/minha-livraria/app/Models/Wishlist.php
@@ -6,5 +6,18 @@ use Illuminate\Database\Eloquent\Model;
 
 class Wishlist extends Model
 {
-    //
+    protected $fillable = [
+        'user_id',
+        'livro_id',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function livro()
+    {
+        return $this->belongsTo(Livro::class);
+    }
 }

--- a/minha-livraria/app/Services/RecomendacaoService.php
+++ b/minha-livraria/app/Services/RecomendacaoService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Livro;
+use App\Models\User;
+
+class RecomendacaoService
+{
+    /**
+     * Retorna uma coleção de livros recomendados.
+     */
+    public function recomendar(Livro $livro, ?User $user = null, int $limit = 4)
+    {
+        $categorias = collect([$livro->categoria_id]);
+
+        if ($user) {
+            $categoriasCompradas = $user->pedidos()
+                ->with('itens.livro')
+                ->get()
+                ->pluck('itens.*.livro.categoria_id')
+                ->flatten()
+                ->unique();
+
+            $categorias = $categorias->merge($categoriasCompradas);
+        }
+
+        return Livro::whereIn('categoria_id', $categorias->unique())
+            ->where('id', '!=', $livro->id)
+            ->ativo()
+            ->inRandomOrder()
+            ->limit($limit)
+            ->get();
+    }
+}

--- a/minha-livraria/routes/web.php
+++ b/minha-livraria/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\PedidoController;
 use App\Http\Controllers\AvaliacaoController;
 use App\Http\Controllers\NewsletterController;
 use App\Http\Controllers\WishlistController;
+use App\Http\Controllers\RecomendacaoController;
 
 // Admin Controllers
 use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
@@ -158,7 +159,7 @@ Route::prefix('api')->name('api.')->group(function () {
 Route::get('/buscar', [LivroController::class, 'buscar'])->name('livros.buscar');
 
 // Rota para recomendações
-Route::get('/recomendacoes/{livro}', [App\Http\Controllers\RecomendacaoController::class, 'show'])->name('recomendacoes.show');
+Route::get('/recomendacoes/{livro}', [RecomendacaoController::class, 'show'])->name('recomendacoes.show');
 
 // Rota de fallback para páginas não encontradas
 Route::fallback(function () {


### PR DESCRIPTION
## Summary
- add fillable attributes and relationships across models
- implement book recommendation service
- show recommendations in LivroController
- expose recommendation endpoint

## Testing
- `vendor/bin/phpunit --stop-on-defect` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6845039241c883279925f428d9be45aa