### PR TITLE
Add is_admin to fillable

### DIFF
--- a/minha-livraria/app/Models/User.php
+++ b/minha-livraria/app/Models/User.php
@@ -25,6 +25,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'is_admin',
     ];
 
     /**


### PR DESCRIPTION
## Summary
- allow mass assignment of `is_admin`

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --stop-on-failure --colors=never` *(fails: Call to undefined method App\Http\Controllers\Admin\DashboardController::middleware())*

------
https://chatgpt.com/codex/tasks/task_e_6845c699c0a88327a4f852ada5ef67b1