### PR TITLE
Add columns to avaliacaos migration

### DIFF
--- a/minha-livraria/database/migrations/2025_06_08_020040_create_avaliacaos_table.php
+++ b/minha-livraria/database/migrations/2025_06_08_020040_create_avaliacaos_table.php
@@ -13,7 +13,17 @@ return new class extends Migration
     {
         Schema::create('avaliacaos', function (Blueprint $table) {
             $table->id();
+
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('livro_id')->constrained('livros')->onDelete('cascade');
+            $table->unsignedTinyInteger('rating');
+            $table->text('comentario')->nullable();
+            $table->enum('status', ['pendente', 'aprovado', 'rejeitado'])->default('pendente');
+
             $table->timestamps();
+
+            // Índices adicionais para consultas frequentes
+            $table->index(['livro_id', 'status']);
         });
     }
 


### PR DESCRIPTION
## Summary
- expand `avaliacaos` migration with fields referenced in the model

## Testing
- `php artisan migrate --force`
- `php artisan test` *(fails: 11 failed, 19 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6845c69b8ab883279d4a977222e44442