### PR TITLE
Add shipping address fields to pedidos

### DIFF
--- a/minha-livraria/app/Models/Pedido.php
+++ b/minha-livraria/app/Models/Pedido.php
@@ -12,8 +12,9 @@ class Pedido extends Model
 
     protected $fillable = [
         'numero_pedido', 'user_id', 'nome_cliente', 'email_cliente',
-        'telefone_cliente', 'endereco_entrega', 'total', 'status',
-        'forma_pagamento', 'data_entrega'
+        'telefone_cliente', 'endereco_entrega',
+        'cidade', 'estado', 'cep',
+        'total', 'status', 'forma_pagamento', 'data_entrega'
     ];
 
     protected $casts = [

--- a/minha-livraria/database/migrations/2025_06_08_020030_create_pedidos_table.php
+++ b/minha-livraria/database/migrations/2025_06_08_020030_create_pedidos_table.php
@@ -17,6 +17,9 @@ return new class extends Migration
             $table->string('email_cliente');
             $table->string('telefone_cliente');
             $table->text('endereco_entrega');
+            $table->string('cidade');
+            $table->string('estado', 2);
+            $table->string('cep', 9);
             $table->decimal('total', 10, 2);
             $table->enum('status', ['pendente', 'processando', 'enviado', 'entregue', 'cancelado'])->default('pendente');
             $table->enum('forma_pagamento', ['cartao_credito', 'cartao_debito', 'pix', 'boleto']);

--- a/minha-livraria/tests/Feature/CheckoutTest.php
+++ b/minha-livraria/tests/Feature/CheckoutTest.php
@@ -27,6 +27,9 @@ class CheckoutTest extends TestCase
             'email_cliente' => 'john@example.com',
             'telefone_cliente' => '123456789',
             'endereco_entrega' => 'Rua Teste, 123',
+            'cidade' => 'Sao Paulo',
+            'estado' => 'SP',
+            'cep' => '12345-678',
             'forma_pagamento' => 'pix',
         ]);
 


### PR DESCRIPTION
## Summary
- extend pedidos migration
- update Pedido fillable fields
- include new address fields in checkout feature test

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c69ca19c8327b2e6ccadf20a54ef