### PR TITLE
Remove unused admin routes

### DIFF
--- a/minha-livraria/app/Http/Controllers/Admin/DashboardController.php
+++ b/minha-livraria/app/Http/Controllers/Admin/DashboardController.php
@@ -265,8 +265,7 @@ class DashboardController extends Controller
                 'tipo' => 'warning',
                 'titulo' => 'Estoque Baixo',
                 'mensagem' => "{$estoqueBaixo} livro(s) com estoque baixo",
-                'icone' => 'fas fa-exclamation-triangle',
-                'acao' => route('admin.livros.index', ['filtro' => 'estoque_baixo'])
+                'icone' => 'fas fa-exclamation-triangle'
             ];
         }
 
@@ -278,8 +277,7 @@ class DashboardController extends Controller
                 'tipo' => 'info',
                 'titulo' => 'Avaliações Pendentes',
                 'mensagem' => "{$avaliacoesPendentes} avaliação(ões) aguardando moderação",
-                'icone' => 'fas fa-star',
-                'acao' => route('admin.avaliacoes.index', ['status' => 'pendente'])
+                'icone' => 'fas fa-star'
             ];
         }
 
@@ -293,8 +291,7 @@ class DashboardController extends Controller
                 'tipo' => 'warning',
                 'titulo' => 'Pedidos Pendentes',
                 'mensagem' => "{$pedidosPendentes} pedido(s) pendente(s) nas últimas 24h",
-                'icone' => 'fas fa-clock',
-                'acao' => route('admin.pedidos.index', ['status' => 'pendente'])
+                'icone' => 'fas fa-clock'
             ];
         }
 
@@ -308,8 +305,7 @@ class DashboardController extends Controller
                 'tipo' => 'warning',
                 'titulo' => 'Livros sem Categoria',
                 'mensagem' => "{$livrosSemCategoria} livro(s) sem categoria definida",
-                'icone' => 'fas fa-tags',
-                'acao' => route('admin.livros.index', ['filtro' => 'sem_categoria'])
+                'icone' => 'fas fa-tags'
             ];
         }
 

--- a/minha-livraria/resources/views/layouts/store.blade.php
+++ b/minha-livraria/resources/views/layouts/store.blade.php
@@ -417,7 +417,6 @@
                                 @if (Auth::user()->is_admin ?? false)
                                     <li><hr class="dropdown-divider"></li>
                                     <li><a class="dropdown-item" href="{{ route('admin.dashboard') }}">Painel Admin</a></li>
-                                    <li><a class="dropdown-item" href="{{ route('admin.livros.create') }}">Adicionar Livro</a></li>
                                 @endif
                                 <li><hr class="dropdown-divider"></li>
                                 <li>

--- a/minha-livraria/routes/web.php
+++ b/minha-livraria/routes/web.php
@@ -98,35 +98,6 @@ Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(fun
     // Dashboard
     Route::get('/', [AdminDashboardController::class, 'index'])->name('dashboard');
     
-    // Gestão de Livros
-    Route::resource('livros', AdminLivroController::class);
-    Route::patch('livros/{livro}/toggle-status', [AdminLivroController::class, 'toggleStatus'])->name('livros.toggle-status');
-    Route::patch('livros/{livro}/toggle-destaque', [AdminLivroController::class, 'toggleDestaque'])->name('livros.toggle-destaque');
-    
-    // Gestão de Categorias
-    Route::resource('categorias', AdminCategoriaController::class);
-    Route::patch('categorias/{categoria}/toggle-status', [AdminCategoriaController::class, 'toggleStatus'])->name('categorias.toggle-status');
-    
-    // Gestão de Pedidos
-    Route::resource('pedidos', AdminPedidoController::class)->only(['index', 'show', 'update']);
-    Route::patch('pedidos/{pedido}/status', [AdminPedidoController::class, 'updateStatus'])->name('pedidos.update-status');
-    
-    // Gestão de Cupons
-    Route::resource('cupons', AdminCupomController::class);
-    Route::patch('cupons/{cupom}/toggle-status', [AdminCupomController::class, 'toggleStatus'])->name('cupons.toggle-status');
-    
-    // Gestão de Avaliações
-    Route::resource('avaliacoes', AdminAvaliacaoController::class)->only(['index', 'show', 'update', 'destroy']);
-    Route::patch('avaliacoes/{avaliacao}/toggle-status', [AdminAvaliacaoController::class, 'toggleStatus'])->name('avaliacoes.toggle-status');
-    
-    // Relatórios
-    Route::prefix('relatorios')->name('relatorios.')->group(function () {
-        Route::get('/', [AdminRelatorioController::class, 'index'])->name('index');
-        Route::get('/vendas', [AdminRelatorioController::class, 'vendas'])->name('vendas');
-        Route::get('/estoque', [AdminRelatorioController::class, 'estoque'])->name('estoque');
-        Route::get('/clientes', [AdminRelatorioController::class, 'clientes'])->name('clientes');
-        Route::get('/avaliacoes', [AdminRelatorioController::class, 'avaliacoes'])->name('avaliacoes');
-    });
 });
 
 /*


### PR DESCRIPTION
## Summary
- prune admin routes that point to empty controllers
- drop link to create book from dropdown
- stop referencing removed routes from Dashboard alerts

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6845c69f090c8327b4f12ba7599176f0