### PR TITLE
Fix payment field name in order processing

### DIFF
--- a/minha-livraria/app/Actions/Pedidos/ProcessarPedidoAction.php
+++ b/minha-livraria/app/Actions/Pedidos/ProcessarPedidoAction.php
@@ -46,7 +46,7 @@ class ProcessarPedidoAction
                 'cidade' => $data['cidade'],
                 'estado' => $data['estado'],
                 'cep' => $data['cep'],
-                'metodo_pagamento' => $data['metodo_pagamento'],
+                'forma_pagamento' => $data['forma_pagamento'],
             ]);
 
             // 3. Mover os itens do carrinho para a tabela de itens do pedido e abater o stock.


### PR DESCRIPTION
## Summary
- rename `metodo_pagamento` to `forma_pagamento` in `ProcessarPedidoAction`

## Testing
- `composer test` *(fails: vendor dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845c6a060f48327925daac7d0e021eb