### PR TITLE
Add basic wishlist & newsletter features

### DIFF
--- a/minha-livraria/app/Http/Controllers/NewsletterController.php
+++ b/minha-livraria/app/Http/Controllers/NewsletterController.php
@@ -2,9 +2,43 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\NewsletterSubscriber;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class NewsletterController extends Controller
 {
-    //
+    /**
+     * Register a new e-mail in the newsletter list.
+     */
+    public function inscrever(Request $request)
+    {
+        $request->validate([
+            'email' => 'required|email|unique:newsletter_subscribers,email',
+        ]);
+
+        NewsletterSubscriber::create([
+            'email' => $request->email,
+            'token' => Str::uuid(),
+            'status' => 'pendente',
+        ]);
+
+        return back()->with('success', 'Inscrição realizada. Verifique seu e-mail para confirmar.');
+    }
+
+    /**
+     * Confirm subscription using the provided token.
+     */
+    public function confirmar($token)
+    {
+        $subscriber = NewsletterSubscriber::where('token', $token)->firstOrFail();
+
+        $subscriber->update([
+            'status' => 'ativo',
+            'confirmed_at' => now(),
+        ]);
+
+        return redirect()->route('livros.index')
+            ->with('success', 'Inscrição confirmada com sucesso.');
+    }
 }

--- a/minha-livraria/app/Http/Controllers/WishlistController.php
+++ b/minha-livraria/app/Http/Controllers/WishlistController.php
@@ -2,9 +2,51 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Wishlist;
 use Illuminate\Http\Request;
 
 class WishlistController extends Controller
 {
-    //
+    /**
+     * Display the authenticated user's wishlist items.
+     */
+    public function index()
+    {
+        $itens = Wishlist::with('livro')
+            ->where('user_id', auth()->id())
+            ->get();
+
+        return view('wishlist.index', compact('itens'));
+    }
+
+    /**
+     * Add a book to the user's wishlist.
+     */
+    public function adicionar(Request $request)
+    {
+        $request->validate([
+            'livro_id' => 'required|exists:livros,id',
+        ]);
+
+        Wishlist::firstOrCreate([
+            'user_id' => $request->user()->id,
+            'livro_id' => $request->livro_id,
+        ]);
+
+        return back()->with('success', 'Livro adicionado à wishlist.');
+    }
+
+    /**
+     * Remove an item from the user's wishlist.
+     */
+    public function remover(Wishlist $item)
+    {
+        if ($item->user_id !== auth()->id()) {
+            abort(403);
+        }
+
+        $item->delete();
+
+        return back()->with('success', 'Item removido da wishlist.');
+    }
 }

--- a/minha-livraria/resources/views/wishlist/index.blade.php
+++ b/minha-livraria/resources/views/wishlist/index.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('title', 'Minha Wishlist')
+
+@section('content')
+<div class="container my-5">
+    <h2 class="mb-4">💖 Minha Wishlist</h2>
+
+    @if($itens->isEmpty())
+        <p class="text-muted">Você ainda não adicionou nenhum livro à sua wishlist.</p>
+    @else
+        <ul class="list-group">
+            @foreach($itens as $item)
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>{{ $item->livro->titulo }}</span>
+                    <form action="{{ route('wishlist.remover', $item) }}" method="POST" class="ms-3">
+                        @csrf
+                        @method('DELETE')
+                        <button class="btn btn-sm btn-outline-danger">Remover</button>
+                    </form>
+                </li>
+            @endforeach
+        </ul>
+    @endif
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- implement wishlist and newsletter controller logic
- provide simple wishlist view

## Testing
- `php artisan test` *(fails: CheckoutTest and other feature tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845ccb75a8483278df068ff9b262616